### PR TITLE
CIとCDのstatus badgeを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,27 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: ci
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
   pull_request:
-    branches: [ "master" ]
+    branches: ['master']
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
-    - run: yarn install --frozen-lockfile
-    - run: yarn build
-    - run: yarn lint
-    - run: yarn test
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn lint
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![](https://github.com/shonishi/fe-nextjs-sample/actions/workflows/ci.yml/badge.svg?branch=master)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/9c4a43e7-4738-4856-9bc2-574fc0e8b9fc/deploy-status?branch=master)](https://app.netlify.com/sites/shonishi-fe-nextjs-sample/deploys)
 
 # fe-nextjs-sample
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/shonishi/fe-nextjs-sample/actions/workflows/ci.yml/badge.svg?branch=master)
+
 # fe-nextjs-sample
 
 Next.js を使用した fe サーバのサンプルです
@@ -24,3 +26,7 @@ http://localhost:3000/product/overviews へアクセス
 yarn lint
 yarn test
 ```
+
+## CI
+
+Github Actions を使用しています。master ブランチへの PR/マージ時にビルド、静的解析、テストが実施されます。

--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ yarn test
 ## CI
 
 Github Actions を使用しています。master ブランチへの PR/マージ時にビルド、静的解析、テストが実施されます。
+
+## CD
+
+master ブランチへのマージで netlify へデプロイされます。
+
+https://shonishi-fe-nextjs-sample.netlify.app/product/overviews へアクセス


### PR DESCRIPTION
CD先としてnetlifyを選定。選定理由は無期限で無料だったため。
netlify側にmasterブランチ更新でデプロイする設定を入れたため、その説明文を追加。
CIとCDのstatus badgeをREADMEに追加。