### PR TITLE
jestのcoverage対象からstoriesを除外

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,8 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.stories.ts'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "test": "jest --collectCoverage --collectCoverageFrom='src/**/*.{ts,tsx}'",
+    "test": "jest",
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
jestのcoverage対象に、意図せずstorybookのファイル（*.stories.ts）が含まれていたため、除外します。