### PR TITLE
ssrでの描画処理を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,45 +3,39 @@
 
 # fe-nextjs-sample
 
-Next.js を使用した fe サーバのサンプルです
+Next.js を使用した fe サーバのサンプルです。
+1 つのテンプレートを、csr と ssr の 2 つの方法で描画します。
 
-## 環境構築
+## ローカルでの環境構築
 
-ライブラリのインストール
+### ライブラリのインストール
 
 ```
 yarn install
 ```
 
-ビルド
+### ビルド
 
 ```
 yarn build
 ```
 
-アプリの起動
+### アプリの起動
 
 ```
 yarn start
 ```
 
-開発者モードでのアプリの起動
+開発者モードの場合
 
 ```
 yarn dev
 ```
 
-画面の表示
+### 画面の表示
 
-```
-http://localhost:3000/product/overviews
-```
-
-## component の表示確認
-
-```
-yarn storybook
-```
+1. csr : http://localhost:3000/product/overviews/csr
+1. ssr : http://localhost:3000/product/overviews/ssr
 
 ## 静的解析
 
@@ -55,6 +49,12 @@ yarn lint
 yarn test
 ```
 
+## component 単位の表示確認
+
+```
+yarn storybook
+```
+
 ## CI
 
 Github Actions で、master ブランチへの PR/マージ時にビルド、静的解析、テストが実施されます。
@@ -63,8 +63,9 @@ Github Actions で、master ブランチへの PR/マージ時にビルド、静
 
 master ブランチへのマージで netlify へデプロイされます。
 
-https://shonishi-fe-nextjs-sample.netlify.app/product/overviews へアクセス
+1. csr : https://shonishi-fe-nextjs-sample.netlify.app/product/overviews/csr
+1. ssr : https://shonishi-fe-nextjs-sample.netlify.app/product/overviews/ssr
 
 さらに、そのソースの storybook が GitHubPages へ公開されます。
 
-https://shonishi.github.io/fe-nextjs-sample/ へアクセス
+https://shonishi.github.io/fe-nextjs-sample/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.3",
     "next": "13.2.4",
+    "next-redux-wrapper": "^8.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-redux": "^8.0.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,16 @@
-import { store } from '@/src/ducks/store';
+import { wrapper } from '@/src/ducks/store';
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
+import { FC } from 'react';
 import { Provider } from 'react-redux';
 
-const App = ({ Component, pageProps }: AppProps) => {
+const MyApp: FC<AppProps> = ({ Component, ...rest }) => {
+  const { store, props } = wrapper.useWrappedStore(rest);
   return (
     <Provider store={store}>
-      <Component {...pageProps} />
+      <Component {...props.pageProps} />
     </Provider>
   );
 };
 
-export default App;
+export default MyApp;

--- a/pages/product/overviews/csr.tsx
+++ b/pages/product/overviews/csr.tsx
@@ -1,5 +1,5 @@
 import Overviews from '@/src/containers/templates/Overviews';
 
-export default function Page() {
+export default function CsrPage() {
   return <Overviews />;
 }

--- a/pages/product/overviews/ssr.tsx
+++ b/pages/product/overviews/ssr.tsx
@@ -1,0 +1,18 @@
+import Overviews from '@/src/containers/templates/Overviews';
+import { setLoadData } from '@/src/ducks/overviews/slice';
+import { wrapper } from '@/src/ducks/store';
+import { fetchProductOverviews } from '@/src/repository/client/fetchProductOverviews';
+import { GetServerSideProps } from 'next';
+
+export default function SsrPage() {
+  return <Overviews />;
+}
+
+export const getServerSideProps: GetServerSideProps =
+  wrapper.getServerSideProps((store) => async () => {
+    const loadData = await fetchProductOverviews();
+    store.dispatch(setLoadData(loadData));
+    return {
+      props: {},
+    };
+  });

--- a/src/containers/templates/Overviews/index.test.tsx
+++ b/src/containers/templates/Overviews/index.test.tsx
@@ -1,13 +1,13 @@
 import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { store } from '@/src/ducks/store';
+import { makeStore } from '@/src/ducks/store';
 import Overviews from '.';
 
 describe('Overviews', () => {
   it('初期表示で正常にレンダリングされること', async () => {
     render(
-      <Provider store={store}>
+      <Provider store={makeStore()}>
         <Overviews />
       </Provider>,
     );
@@ -17,7 +17,7 @@ describe('Overviews', () => {
 
   it('色をクリックした場合、その色が選択状態になること', async () => {
     render(
-      <Provider store={store}>
+      <Provider store={makeStore()}>
         <Overviews />
       </Provider>,
     );
@@ -30,7 +30,7 @@ describe('Overviews', () => {
 
   it('サイズをクリックした場合、そのサイズが選択状態になること', async () => {
     render(
-      <Provider store={store}>
+      <Provider store={makeStore()}>
         <Overviews />
       </Provider>,
     );

--- a/src/ducks/overviews/hooks.ts
+++ b/src/ducks/overviews/hooks.ts
@@ -6,13 +6,13 @@ import { changeColor, changeSize, selectOverviews } from './slice';
 export const useOverviewsViewModel = () => {
   const loadData = useAppSelector(selectOverviews).loadData;
   const dispatch = useAppDispatch();
-  const loading = useRef(false);
+  const loaded = useRef(loadData ? true : false);
   useEffect(() => {
-    if (!loading.current) {
-      loading.current = true;
+    if (!loaded.current) {
+      loaded.current = true;
       dispatch(load());
     }
-  }, [loading, dispatch]);
+  }, [loaded, dispatch]);
 
   return {
     loadData,

--- a/src/ducks/overviews/slice.ts
+++ b/src/ducks/overviews/slice.ts
@@ -1,6 +1,7 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../store';
 import { load } from './asyncActions';
+import Response from '@/src/repository/client/fetchProductOverviews/response';
 
 export interface OverviewsState {
   loadData?: {
@@ -45,6 +46,9 @@ export const overviewsSlice = createSlice({
         state.loadData.selectedSizeId = action.payload;
       }
     },
+    setLoadData: (state, action: PayloadAction<Response>) => {
+      state.loadData = convertResponseToState(action.payload);
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -52,19 +56,24 @@ export const overviewsSlice = createSlice({
         state.loadData = undefined;
       })
       .addCase(load.fulfilled, (state, action) => {
-        const selectedSize = action.payload.sizes.find((size) => size.inStock);
-        const selectedSizeId = selectedSize
-          ? selectedSize.id
-          : // 本来であれば在庫がない旨の表示をするべき。サンプルのため処理を簡略化する。
-            0;
-        state.loadData = {
-          ...action.payload,
-          selectedColorId: action.payload.colors[0].id,
-          selectedSizeId: selectedSizeId,
-        };
+        state.loadData = convertResponseToState(action.payload);
       });
   },
 });
-export const { changeColor, changeSize } = overviewsSlice.actions;
+
+const convertResponseToState = (response: Response) => {
+  const selectedSize = response.sizes.find((size) => size.inStock);
+  const selectedSizeId = selectedSize
+    ? selectedSize.id
+    : // 本来であれば在庫がない旨の表示をするべき。サンプルのため処理を簡略化する。
+      0;
+  return {
+    ...response,
+    selectedColorId: response.colors[0].id,
+    selectedSizeId: selectedSizeId,
+  };
+};
+
+export const { changeColor, changeSize, setLoadData } = overviewsSlice.actions;
 export const selectOverviews = (state: RootState) => state.overviews;
 export default overviewsSlice;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7436,6 +7436,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+next-redux-wrapper@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-8.1.0.tgz#d9c135f1ceeb2478375bdacd356eb9db273d3a07"
+  integrity sha512-2hIau0hcI6uQszOtrvAFqgc0NkZegKYhBB7ZAKiG3jk7zfuQb4E7OV9jfxViqqojh3SEHdnFfPkN9KErttUKuw==
+
 next@13.2.4:
   version "13.2.4"
   resolved "https://registry.yarnpkg.com/next/-/next-13.2.4.tgz#2363330392b0f7da02ab41301f60857ffa7f67d6"


### PR DESCRIPTION
元のpageをcsrとssrに分け、csrはそのまま（元からcsrのため）、ssrの方に処理を追加しました。
主な修正内容は以下です。
1. getServerSidePropsでデータをfetchし、storeへ保存するactionを実行
2. viewModelを、データがすでに存在する場合はfetchしないように変更（containerをcsrとssrで共有するため）
3. next-redux-wrapperを導入し、サーバ側のstoreをクライアント側へ同期するように変更
