### PR TITLE
ducksの単体テスト

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "autoprefixer": "^10.4.14",
+    "babel-plugin-dynamic-import-node": "^2.3.3",
     "cypress": "^12.11.0",
     "eslint": "^8.37.0",
     "eslint-config-next": "^13.2.4",

--- a/src/containers/templates/Overviews/index.test.tsx
+++ b/src/containers/templates/Overviews/index.test.tsx
@@ -16,21 +16,7 @@ jest.mock('@/src/ducks/overviews/hooks', () => {
   };
 });
 
-jest.mock(
-  '@/src/components/templates/Overviews',
-  () =>
-    ({
-      loadData,
-      changeColor,
-      changeSize,
-    }: ReturnType<typeof useOverviewsViewModel>) => {
-      return {
-        loadData,
-        changeColor,
-        changeSize,
-      };
-    },
-);
+jest.mock('@/src/components/templates/Overviews');
 
 describe('Overviews', () => {
   afterEach(() => {

--- a/src/containers/templates/Overviews/index.test.tsx
+++ b/src/containers/templates/Overviews/index.test.tsx
@@ -6,7 +6,6 @@ const changeColorMock = jest.fn();
 const changeSizeMock = jest.fn();
 jest.mock('@/src/ducks/overviews/hooks', () => {
   return {
-    __esModule: true,
     useOverviewsViewModel: jest.fn(() => {
       return {
         loadData: loadDataMock,
@@ -40,12 +39,10 @@ describe('Overviews', () => {
   it('Overviewsのtemplateを返すこと', () => {
     const result = Overviews();
     expect((useOverviewsViewModel as jest.Mock).mock.calls).toHaveLength(1);
-    expect(result.props).toEqual(
-      expect.objectContaining({
-        loadData: loadDataMock,
-        changeColor: changeColorMock,
-        changeSize: changeSizeMock,
-      }),
-    );
+    expect(result.props).toEqual({
+      loadData: loadDataMock,
+      changeColor: changeColorMock,
+      changeSize: changeSizeMock,
+    });
   });
 });

--- a/src/ducks/hooks.test.ts
+++ b/src/ducks/hooks.test.ts
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from './hooks';
+
+const dispatchMock = new (jest.fn())();
+jest.mock('react-redux', () => {
+  return {
+    ...jest.requireActual('react-redux'),
+    useDispatch: () => dispatchMock,
+  };
+});
+
+describe('hooks', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('useAppDispatchを実行すると、useDispatchが返されること', () => {
+    expect(useAppDispatch()).toEqual(dispatchMock);
+  });
+  it('useAppSelectorは、useSelectorであること', () => {
+    expect(useAppSelector).toEqual(useSelector);
+  });
+});

--- a/src/ducks/store.test.ts
+++ b/src/ducks/store.test.ts
@@ -1,0 +1,140 @@
+import { HYDRATE, createWrapper } from 'next-redux-wrapper';
+import { makeStore, wrapper } from './store';
+import { combineReducers } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
+import {
+  overviewsSlice,
+  initialState as overviewsInitialState,
+} from './overviews/slice';
+import logger from 'redux-logger';
+
+jest.mock('@reduxjs/toolkit', () => {
+  return {
+    ...jest.requireActual('@reduxjs/toolkit'),
+    configureStore: jest.fn(),
+  };
+});
+
+jest.mock('redux', () => {
+  return {
+    ...jest.requireActual('redux'),
+    combineReducers: jest.fn(() => () => {
+      return {
+        dummy: 'dummy',
+      };
+    }),
+  };
+});
+
+jest.mock('next-redux-wrapper', () => {
+  return {
+    ...jest.requireActual('next-redux-wrapper'),
+    createWrapper: jest.fn().mockReturnValue({
+      dummy: 'dummy',
+    }),
+  };
+});
+
+describe('store', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('makeStore', () => {
+    describe('reducer', () => {
+      const state = { dummy1: 'dummy1' };
+      const actionPayload = { dummy2: 'dummy2' };
+
+      it('action.typeがHYDRATEの場合、payloadとマージしたstateを返すこと', () => {
+        makeStore();
+        const configureStoreMock = configureStore as jest.Mock;
+        expect(configureStoreMock.mock.calls).toHaveLength(1);
+        const result = configureStoreMock.mock.calls[0][0].reducer(state, {
+          type: HYDRATE,
+          payload: actionPayload,
+        });
+        expect(result).toEqual(Object.assign({}, state, actionPayload));
+      });
+
+      it('action.typeがHYDRATEではない場合、combineReducersの実行結果を返すこと', () => {
+        makeStore();
+        const configureStoreMock = configureStore as jest.Mock;
+        expect(configureStoreMock.mock.calls).toHaveLength(1);
+        const result = configureStoreMock.mock.calls[0][0].reducer(state, {
+          type: 'NOT_HYDRATE',
+          payload: actionPayload,
+        });
+        const combineReducersMock = combineReducers as jest.Mock;
+        expect(combineReducersMock.mock.calls).toHaveLength(1);
+        expect(combineReducersMock.mock.calls[0][0]).toEqual({
+          overviews: overviewsSlice.reducer,
+        });
+        expect(result).toEqual({ dummy: 'dummy' });
+      });
+    });
+
+    describe('middleware', () => {
+      it('redux-loggerを追加すること', () => {
+        makeStore();
+        const configureStoreMock = configureStore as jest.Mock;
+        expect(configureStoreMock.mock.calls).toHaveLength(1);
+        const concatMock = jest.fn();
+        configureStoreMock.mock.calls[0][0].middleware(
+          jest.fn().mockReturnValue({
+            concat: concatMock,
+          }),
+        );
+        expect(concatMock.mock.calls).toHaveLength(1);
+        expect(concatMock.mock.calls[0][0]).toEqual(logger);
+      });
+    });
+
+    describe.each([
+      ['production', false],
+      ['development', true],
+    ])(`devTools`, (nodeEnv, expected) => {
+      const env = process.env;
+
+      beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...env };
+      });
+
+      afterEach(() => {
+        process.env = env;
+      });
+
+      it(`process.env.NODE_ENVが${nodeEnv}の場合、${expected}を返すこと`, () => {
+        process.env = {
+          ...env,
+          NODE_ENV: nodeEnv as 'development' | 'production' | 'test',
+        };
+        makeStore();
+        const configureStoreMock = configureStore as jest.Mock;
+        expect(configureStoreMock.mock.calls).toHaveLength(1);
+        expect(configureStoreMock.mock.calls[0][0].devTools).toBe(expected);
+      });
+    });
+
+    describe('preloadedState', () => {
+      it('preloadedStateを実行すると、初期のstateが返されること', () => {
+        makeStore();
+        const configureStoreMock = configureStore as jest.Mock;
+        expect(configureStoreMock.mock.calls).toHaveLength(1);
+        const result = configureStoreMock.mock.calls[0][0].preloadedState;
+        expect(result).toEqual({ overviews: overviewsInitialState });
+      });
+    });
+  });
+
+  describe('wrapper', () => {
+    it('createWrapperの実行結果を返すこと', () => {
+      const createWrapperMock = createWrapper as jest.Mock;
+      expect(createWrapperMock.mock.calls).toHaveLength(1);
+      expect(createWrapperMock.mock.calls[0][0]).toEqual(makeStore);
+      expect(wrapper).toEqual({
+        dummy: 'dummy',
+      });
+    });
+  });
+});

--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -1,23 +1,33 @@
 import { ThunkAction, configureStore } from '@reduxjs/toolkit';
-import { Action, combineReducers } from 'redux';
+import {
+  Action,
+  AnyAction,
+  CombinedState,
+  Reducer,
+  combineReducers,
+} from 'redux';
 import logger from 'redux-logger';
 import overviewsSlice, {
+  OverviewsState,
   initialState as overviewsInitialState,
 } from '@/src/ducks/overviews/slice';
 import { HYDRATE, createWrapper } from 'next-redux-wrapper';
 
-const combinedReducer = combineReducers({
-  overviews: overviewsSlice.reducer,
-});
-
-const reducer: typeof combinedReducer = (state, action) => {
+const reducer: Reducer<
+  CombinedState<{
+    overviews: OverviewsState;
+  }>,
+  AnyAction
+> = (state, action) => {
   if (action.type === HYDRATE) {
     return {
       ...state,
       ...action.payload,
     };
   } else {
-    return combinedReducer(state, action);
+    return combineReducers({
+      overviews: overviewsSlice.reducer,
+    })(state, action);
   }
 };
 

--- a/src/ducks/store.ts
+++ b/src/ducks/store.ts
@@ -1,33 +1,23 @@
 import { ThunkAction, configureStore } from '@reduxjs/toolkit';
-import {
-  Action,
-  AnyAction,
-  CombinedState,
-  Reducer,
-  combineReducers,
-} from 'redux';
+import { Action, combineReducers } from 'redux';
 import logger from 'redux-logger';
 import overviewsSlice, {
-  OverviewsState,
   initialState as overviewsInitialState,
 } from '@/src/ducks/overviews/slice';
 import { HYDRATE, createWrapper } from 'next-redux-wrapper';
 
-const reducer: Reducer<
-  CombinedState<{
-    overviews: OverviewsState;
-  }>,
-  AnyAction
-> = (state, action) => {
+const combinedReducer = combineReducers({
+  overviews: overviewsSlice.reducer,
+});
+
+const reducer: typeof combinedReducer = (state, action) => {
   if (action.type === HYDRATE) {
     return {
       ...state,
       ...action.payload,
     };
   } else {
-    return combineReducers({
-      overviews: overviewsSlice.reducer,
-    })(state, action);
+    return combinedReducer(state, action);
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3826,6 +3826,13 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==
 
+babel-plugin-dynamic-import-node@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
+  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
+  dependencies:
+    object.assign "^4.1.0"
+
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
@@ -8058,7 +8065,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.3, object.assign@^4.1.4:
+object.assign@^4.1.0, object.assign@^4.1.3, object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==


### PR DESCRIPTION
https://github.com/shonishi/fe-nextjs-sample/issues/16
ducks配下のソースの単体テストです。
テストの中で動的importする必要があったため、babel-plugin-dynamic-import-nodeを導入しています。