### PR TITLE
ducks/overviewsの単体テスト

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@testing-library/cypress": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/node": "^18.15.11",
     "@types/react": "^18.0.33",

--- a/src/ducks/overviews/asyncActions.ts
+++ b/src/ducks/overviews/asyncActions.ts
@@ -1,6 +1,0 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
-import { fetchProductOverviews } from '@/src/repository/client/fetchProductOverviews';
-
-export const load = createAsyncThunk('Overviews/load', async () => {
-  return await fetchProductOverviews();
-});

--- a/src/ducks/overviews/hooks.test.ts
+++ b/src/ducks/overviews/hooks.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { changeColor, changeSize, load, selectOverviews } from './slice';
+import { useAppDispatch, useAppSelector } from '../hooks';
+import { useOverviewsViewModel } from './hooks';
+
+jest.mock('../hooks');
+jest.mock('./slice');
+
+describe('useOverviewsViewModel', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stateにloadDataが存在しない場合、loadをdispatchすること', async () => {
+    (useAppSelector as jest.Mock).mockReturnValueOnce({});
+    const dispatchMock = jest.fn();
+    (useAppDispatch as jest.Mock).mockReturnValueOnce(dispatchMock);
+    const loadResultMock = new (jest.fn())();
+    (load as unknown as jest.Mock).mockReturnValueOnce(loadResultMock);
+
+    const { result } = renderHook(() => useOverviewsViewModel());
+
+    expect((useAppSelector as jest.Mock).mock.calls).toHaveLength(1);
+    expect(
+      JSON.stringify((useAppSelector as jest.Mock).mock.calls[0][0]),
+    ).toEqual(JSON.stringify(selectOverviews));
+    expect((useAppDispatch as jest.Mock).mock.calls).toHaveLength(1);
+    expect(dispatchMock.mock.calls).toHaveLength(1);
+    expect(dispatchMock.mock.calls[0][0]).toEqual(loadResultMock);
+    expect(result.current.loadData).toBeUndefined();
+  });
+
+  it('stateにloadDataが存在する場合、loadをdispatchしないこと', async () => {
+    (useAppSelector as jest.Mock).mockReturnValueOnce({
+      loadData: { dummy: 'dummuy' },
+    });
+    const dispatchMock = jest.fn();
+    (useAppDispatch as jest.Mock).mockReturnValueOnce(dispatchMock);
+
+    const { result } = renderHook(() => useOverviewsViewModel());
+
+    expect((useAppSelector as jest.Mock).mock.calls).toHaveLength(1);
+    expect(
+      JSON.stringify((useAppSelector as jest.Mock).mock.calls[0][0]),
+    ).toEqual(JSON.stringify(selectOverviews));
+    expect((useAppDispatch as jest.Mock).mock.calls).toHaveLength(1);
+    expect(dispatchMock.mock.calls).toHaveLength(0);
+    expect(result.current.loadData).toEqual({ dummy: 'dummuy' });
+  });
+
+  it('changeColorとchangeSizeを実行すると、それぞれのactionがdispatchされること', async () => {
+    (useAppSelector as jest.Mock).mockReturnValueOnce({
+      loadData: { dummy: 'dummuy' },
+    });
+    const dispatchMock = jest.fn();
+    (useAppDispatch as jest.Mock).mockReturnValueOnce(dispatchMock);
+
+    const { result } = renderHook(() => useOverviewsViewModel());
+
+    jest.clearAllMocks();
+    const changeColorMock = changeColor as unknown as jest.Mock;
+    result.current.changeColor({ id: 1 });
+    expect(dispatchMock.mock.calls).toHaveLength(1);
+    expect(changeColorMock.mock.calls).toHaveLength(1);
+    expect(changeColorMock.mock.calls[0][0]).toEqual(1);
+
+    jest.clearAllMocks();
+    const changeSizeMock = changeSize as unknown as jest.Mock;
+    result.current.changeSize({ id: 2 });
+    expect(dispatchMock.mock.calls).toHaveLength(1);
+    expect(changeSizeMock.mock.calls).toHaveLength(1);
+    expect(changeSizeMock.mock.calls[0][0]).toEqual(2);
+  });
+});

--- a/src/ducks/overviews/hooks.ts
+++ b/src/ducks/overviews/hooks.ts
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from '../hooks';
-import { load } from './asyncActions';
+import { load } from './slice';
 import { changeColor, changeSize, selectOverviews } from './slice';
 
 export const useOverviewsViewModel = () => {

--- a/src/ducks/overviews/slice.test.ts
+++ b/src/ducks/overviews/slice.test.ts
@@ -1,0 +1,217 @@
+import overviewsSlice, {
+  changeColor,
+  changeSize,
+  initialState,
+  load,
+  selectOverviews,
+  setLoadData,
+} from './slice';
+
+jest.mock('@/src/repository/client/fetchProductOverviews', () => {
+  return {
+    fetchProductOverviews: jest.fn().mockReturnValue(Promise.resolve()),
+  };
+});
+
+describe('slice', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const response = {
+    id: 4,
+    name: 'あひるちゃん 5羽セット',
+    price: Math.floor(Math.random() * 1000) + '円',
+    href: '#',
+    breadcrumbs: [
+      { id: 1, name: 'おもちゃ', href: '#' },
+      { id: 2, name: '赤ちゃん・幼児', href: '#' },
+      { id: 3, name: 'お風呂用', href: '#' },
+    ],
+    images: [
+      {
+        src: 'https://www.pakutaso.com/shared/img/thumb/PAK74_ahirucyansusumu_TP_V.jpg',
+        alt: 'Two each of gray, white, and black shirts laying flat.',
+      },
+      {
+        src: 'https://www.pakutaso.com/shared/img/thumb/PAK85_enjinahirucyan_TP_V.jpg',
+        alt: 'Model wearing plain black basic tee.',
+      },
+      {
+        src: 'https://www.pakutaso.com/shared/img/thumb/PAK88_amazonst_TP_V.jpg',
+        alt: 'Model wearing plain gray basic tee.',
+      },
+      {
+        src: 'https://www.pakutaso.com/shared/img/thumb/NKJ56_dateahiru_TP_V.jpg',
+        alt: 'Model wearing plain white basic tee.',
+      },
+    ],
+    colors: [
+      {
+        id: 1,
+        name: 'Pale yellow',
+        class: 'bg-yellow-50',
+        selectedClass: 'ring-gray-400',
+      },
+      {
+        id: 2,
+        name: 'Yellow',
+        class: 'bg-yellow-100',
+        selectedClass: 'ring-gray-400',
+      },
+      {
+        id: 3,
+        name: 'Dark yellow',
+        class: 'bg-yellow-300',
+        selectedClass: 'ring-gray-900',
+      },
+    ],
+    sizes: [
+      { id: 1, name: 'XXS', inStock: false },
+      { id: 2, name: 'XS', inStock: true },
+      { id: 3, name: 'S', inStock: true },
+      { id: 4, name: 'M', inStock: true },
+      { id: 5, name: 'L', inStock: true },
+      { id: 6, name: 'XL', inStock: true },
+      { id: 7, name: '2XL', inStock: true },
+      { id: 8, name: '3XL', inStock: true },
+    ],
+    description: 'あひるのフィギュアです。お風呂に浮かべて楽しいひと時。',
+    highlights: [
+      'お風呂に浮く',
+      '握ると音が鳴る',
+      'シリコン製で丈夫',
+      'お子様の筋力強化にも',
+    ],
+    details:
+      'かわいいあひるちゃんの5羽セット。シリコン製のため小傷が入りにくく、衛生面も安心です。音を出すにはある程度の力で握る必要がありますので、楽しみながらお子様の筋力を強化することができます。各種サイズをご用意しておりますので、お子様の手の大きさに合う物をお選びいただけます。',
+    reviews: { href: '#', average: 4, totalCount: 117 },
+  };
+
+  const fulfilledState = {
+    loadData: {
+      ...response,
+      selectedColorId: 1,
+      selectedSizeId: 2,
+    },
+  };
+
+  describe('overviewsSlice', () => {
+    describe('load', () => {
+      it('pendingの場合、loadDataを初期化すること', () => {
+        const action = { type: load.pending.type };
+        const state = overviewsSlice.reducer(fulfilledState, action);
+        expect(state).toEqual(initialState);
+      });
+
+      describe('fulfilledの場合', () => {
+        it('在庫があるサイズが存在する場合、先頭のサイズでloadDataを更新すること', () => {
+          const action = { type: load.fulfilled.type, payload: response };
+          const state = overviewsSlice.reducer(initialState, action);
+          expect(state).toEqual(fulfilledState);
+        });
+
+        it('全てのサイズに在庫が存在しない場合、サイズは0でloadDataを更新すること', () => {
+          const action = {
+            type: load.fulfilled.type,
+            payload: {
+              ...response,
+              sizes: [
+                { id: 1, name: 'XXS', inStock: false },
+                { id: 2, name: 'XS', inStock: false },
+                { id: 3, name: 'S', inStock: false },
+                { id: 4, name: 'M', inStock: false },
+                { id: 5, name: 'L', inStock: false },
+                { id: 6, name: 'XL', inStock: false },
+                { id: 7, name: '2XL', inStock: false },
+                { id: 8, name: '3XL', inStock: false },
+              ],
+            },
+          };
+          const state = overviewsSlice.reducer(initialState, action);
+          expect(state).toEqual({
+            loadData: {
+              ...fulfilledState.loadData,
+              sizes: action.payload.sizes,
+              selectedSizeId: 0,
+            },
+          });
+        });
+      });
+    });
+
+    describe('changeColor', () => {
+      it('loadDataが存在する場合、selectedColorIdを更新すること', () => {
+        const action = { type: changeColor.type, payload: 3 };
+        const state = overviewsSlice.reducer(fulfilledState, action);
+        expect(state).toEqual({
+          loadData: { ...fulfilledState.loadData, selectedColorId: 3 },
+        });
+      });
+
+      it('loadDataが存在しない場合、selectedColorIdを更新しないこと', () => {
+        const action = { type: changeColor.type, payload: 3 };
+        const state = overviewsSlice.reducer(initialState, action);
+        expect(state).toEqual(initialState);
+      });
+    });
+
+    describe('changeSize', () => {
+      it('loadDataが存在する場合、selectedSizeIdを更新すること', () => {
+        const action = { type: changeSize.type, payload: 3 };
+        const state = overviewsSlice.reducer(fulfilledState, action);
+        expect(state).toEqual({
+          loadData: { ...fulfilledState.loadData, selectedSizeId: 3 },
+        });
+      });
+
+      it('loadDataが存在しない場合、selectedSizeIdを更新しないこと', () => {
+        const action = { type: changeSize.type, payload: 3 };
+        const state = overviewsSlice.reducer(initialState, action);
+        expect(state).toEqual(initialState);
+      });
+    });
+
+    describe('setLoadData', () => {
+      it('loadDataを更新すること', () => {
+        const action = { type: setLoadData.type, payload: response };
+        const state = overviewsSlice.reducer(initialState, action);
+        expect(state).toEqual(fulfilledState);
+      });
+    });
+  });
+
+  describe('load', () => {
+    it('fetchProductOverviewsを実行すること', () => {
+      jest.resetModules();
+      const createAsyncThunkMock = jest.fn();
+      jest.doMock('@reduxjs/toolkit', () => {
+        return {
+          ...jest.requireActual('@reduxjs/toolkit'),
+          createAsyncThunk: createAsyncThunkMock,
+        };
+      });
+      const fetchProductOverviewsMock = jest
+        .fn()
+        .mockReturnValue(Promise.resolve());
+      jest.doMock('@/src/repository/client/fetchProductOverviews', () => {
+        return {
+          fetchProductOverviews: fetchProductOverviewsMock,
+        };
+      });
+
+      return import('./slice').then(async () => {
+        expect(createAsyncThunkMock.mock.calls).toHaveLength(1);
+        expect(createAsyncThunkMock.mock.calls[0][0]).toEqual('Overviews/load');
+        await createAsyncThunkMock.mock.calls[0][1]();
+        expect(fetchProductOverviewsMock.mock.calls).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('selectOverviews', () => {
+    it('overviewsを返すこと', () => {
+      expect(selectOverviews({ overviews: {} })).toEqual({});
+    });
+  });
+});

--- a/src/ducks/overviews/slice.ts
+++ b/src/ducks/overviews/slice.ts
@@ -1,7 +1,7 @@
-import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../store';
-import { load } from './asyncActions';
 import Response from '@/src/repository/client/fetchProductOverviews/response';
+import { fetchProductOverviews } from '@/src/repository/client/fetchProductOverviews';
 
 export interface OverviewsState {
   loadData?: {
@@ -31,6 +31,10 @@ export interface OverviewsState {
 }
 
 export const initialState: OverviewsState = {};
+
+export const load = createAsyncThunk('Overviews/load', async () => {
+  return await fetchProductOverviews();
+});
 
 export const overviewsSlice = createSlice({
   name: 'Overviews',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,6 +2681,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
@@ -8843,6 +8851,13 @@ react-element-to-jsx-string@^15.0.0:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "18.1.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-inspector@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
https://github.com/shonishi/fe-nextjs-sample/issues/16
custom hookのテストを書きやすくするため、@testing-library/react-hooksを導入しました。